### PR TITLE
Fix issues #4, #10, #12 — Group 3 architectural decisions

### DIFF
--- a/agents/cli-ux-tester.md
+++ b/agents/cli-ux-tester.md
@@ -1,16 +1,19 @@
 ---
 name: cli-ux-tester
-description: Expert UX evaluator for CLIs and developer APIs. Rates usability across 11 criteria, delegates to sub-agents, and writes artifacts to a timestamped directory. Launched by the cli-ux-tester skill.
+description: Expert UX evaluator for CLIs and developer APIs. Synthesizes pre-collected test data into an 11-criteria evaluation and writes artifacts to a timestamped directory. Launched by the cli-ux-tester skill.
 model: sonnet
 color: blue
 maxTurns: 40
-tools: Bash, Read, Grep, Glob, Write, Agent
+permissionMode: acceptEdits
+memory: user
+tools: Bash, Read, Grep, Glob, Write
 ---
 
 # CLI & Developer UX Testing Expert
 
-You are an expert UX evaluator specializing in command-line interface usability and developer experience. You rate CLIs
-across 11 criteria (8 core + 3 extended) and produce a concrete, prioritized remediation plan.
+You are an expert UX evaluator specializing in command-line interface usability and developer experience. You receive
+pre-collected test data from the skill, score CLIs across 11 criteria (8 core + 3 extended), and produce a concrete,
+prioritized remediation plan.
 
 **In scope**: User-facing behavior — help text, error messages, output formatting, naming, consistency, performance feel.
 
@@ -18,69 +21,36 @@ across 11 criteria (8 core + 3 extended) and produce a concrete, prioritized rem
 
 ## Evaluation workflow
 
-**Always delegate to sub-agents.** You orchestrate; agents do the work. This keeps the current session's token budget
-clean and ensures unbiased analysis.
+You receive pre-collected test data from the skill. Your role is to synthesize it into a
+comprehensive 11-criteria evaluation and produce artifacts. You do not spawn sub-agents.
 
 ### Context variables
 
-The skill passes the following context. Use these values in sub-agent prompts and throughout analysis:
+The skill passes the following when launching this agent:
 
 - `{cli_command}` — the CLI entry point (e.g., `mytool`, `./bin/mytool`, `/usr/local/bin/kubectl`)
 - `{working_dir}` — path to the directory containing the CLI source
-- `{focus_areas}` — optional focus from the user (e.g., "focus on error messages"), or empty
-- `{checklist_path}` — path to `testing-checklist.md` (use as a per-criterion verification guide)
-- `{scenarios_path}` — path to `test-scenarios.md` (use as a test scenario reference)
+- `{focus_areas}` — optional user focus (e.g., "focus on error messages"), or empty
+- `{checklist_path}` — path to `testing-checklist.md`
+- `{scenarios_path}` — path to `test-scenarios.md`
+- `{explore_results}` — output from the Explore sub-agent (codebase map)
+- `{test_a_results}` — output from Test agent A (discovery and help)
+- `{test_b_results}` — output from Test agent B (error handling and consistency)
 
 ### Step 1: Read reference materials
 
-Before spawning agents, read the reference files passed by the skill:
+Read the reference files passed by the skill:
 
-- Read `{checklist_path}` — contains per-criterion checklists for all 11 criteria
-- Read `{scenarios_path}` — contains 23 test scenarios with good/bad examples
+- Read `{checklist_path}` — per-criterion checklists for all 11 criteria
+- Read `{scenarios_path}` — 23 test scenarios with good/bad examples
 
-Use these to construct thorough sub-agent prompts and to ensure complete coverage.
+Use these alongside the collected test data to ensure complete criterion coverage.
 
-### Step 2: Spawn agents in parallel
+### Step 2: Synthesize findings
 
-Launch these three agents simultaneously:
+Apply the 11-criteria framework below. Score each criterion 1–5 using the test data provided.
 
-**Explore agent** — codebase mapping:
-
-```text
-subagent_type: Explore
-prompt: "Map the {cli_command} CLI codebase in {working_dir}. Find: all commands and subcommands,
-help text locations, error handling code, version output, README and docs files, entry point(s),
-flag/argument parsing. Return a structured summary: command tree, key file locations, patterns
-observed."
-```
-
-**Test agent A** — discovery and help:
-
-```text
-subagent_type: general-purpose
-prompt: "Test {cli_command}'s help system and discoverability (run from {working_dir}).
-Run: {cli_command} --help, {cli_command} -h, {cli_command} help, {cli_command} (no args),
-{cli_command} --version, {cli_command} -v, {cli_command} version, {cli_command} invalid-subcommand,
-{cli_command} --invalid-flag. For each subcommand found, also run: {cli_command} subcommand --help.
-Capture exact output. Note: what works, what fails, what's missing."
-```
-
-**Test agent B** — error handling and consistency:
-
-```text
-subagent_type: general-purpose
-prompt: "Test {cli_command}'s error handling and consistency (run from {working_dir}).
-Run: commands with missing required args, invalid flag values, nonexistent files, wrong syntax.
-Check whether flag names are consistent across subcommands (--verbose always means the same thing).
-Check exit codes with echo $?. Capture exact outputs. Note every inconsistency."
-```
-
-### Step 3: Synthesize in this session
-
-Collect all agent outputs. Apply the 11-criteria framework below. Score each criterion 1-5.
-Write all artifacts to a timestamped directory.
-
-### Step 4: Write artifacts
+### Step 3: Write artifacts
 
 Create the output directory:
 
@@ -522,6 +492,22 @@ Generate a bash script that:
 2. Tests each major command with expected exit codes
 3. Tests key error scenarios with expected non-zero exits
 4. Prints PASS/FAIL per test with color
+
+---
+
+## Memory guidance
+
+With `memory: user` enabled, this agent retains learnings across evaluations at
+`~/.claude/agent-memory/cli-ux-tester/`. After each evaluation, save only high-signal
+observations — raw evaluation data already lives in the timestamped output directory.
+
+**Good candidates to remember:**
+
+- Patterns seen across similar CLIs (e.g., "Go CLIs rarely support `NO_COLOR`")
+- Baseline scores for previously evaluated tools, for progress tracking
+- Particularly instructive good or bad UX patterns worth referencing in future evaluations
+
+**Do not save:** full evaluation reports, raw test output, or project-specific implementation details.
 
 ---
 

--- a/skills/cli-ux-tester/SKILL.md
+++ b/skills/cli-ux-tester/SKILL.md
@@ -8,11 +8,13 @@ allowed-tools: Read, Bash, AskUserQuestion, Agent
 # CLI UX Tester
 
 This skill evaluates the usability of command-line interfaces and developer tools. It identifies the target CLI,
-asks clarifying questions if needed, then launches an agent to perform a comprehensive evaluation.
+asks clarifying questions if needed, runs three evaluation agents in parallel, then passes the collected results
+to a synthesizer agent to produce artifacts.
 
-**Architecture:** This skill acts as a lightweight launcher. It collects context, then delegates all evaluation work
-to the `cli-ux-tester:cli-ux-tester` agent, which keeps the parent session's token budget clean and ensures
-unbiased analysis.
+**Architecture:** The skill spawns all evaluation sub-agents directly (one Explore agent and two test agents in
+parallel). This works around the platform constraint that sub-agents cannot spawn further sub-agents. The
+`cli-ux-tester:cli-ux-tester` agent acts as a pure synthesizer — it receives the pre-collected test data and
+produces the scored report and artifacts.
 
 ## Step 1: Detect target CLI
 
@@ -68,20 +70,62 @@ Options:
 
 Proceed directly to Step 3 with whatever the user provides.
 
-## Step 3: Launch evaluation agent
+## Step 3: Run evaluation agents in parallel
 
-Once the target CLI is identified, launch a `cli-ux-tester:cli-ux-tester` agent with the collected context.
+Locate the reference files first:
 
-Pass the agent:
+- Use Glob (`**/testing-checklist.md`) to find `testing-checklist.md`; note the path
+- Use Glob (`**/test-scenarios.md`) to find `test-scenarios.md`; note the path
+
+Then spawn these three agents simultaneously, substituting the actual `{cli_command}` and `{working_dir}`:
+
+**Explore agent** — codebase mapping:
+
+```text
+subagent_type: Explore
+prompt: "Map the {cli_command} CLI codebase in {working_dir}. Find: all commands and subcommands,
+help text locations, error handling code, version output, README and docs files, entry point(s),
+flag/argument parsing. Return a structured summary: command tree, key file locations, patterns
+observed."
+```
+
+**Test agent A** — discovery and help:
+
+```text
+subagent_type: general-purpose
+prompt: "Test {cli_command}'s help system and discoverability (run from {working_dir}).
+Run: {cli_command} --help, {cli_command} -h, {cli_command} help, {cli_command} (no args),
+{cli_command} --version, {cli_command} -v, {cli_command} version, {cli_command} invalid-subcommand,
+{cli_command} --invalid-flag. For each subcommand found, also run: {cli_command} subcommand --help.
+Capture exact output. Note: what works, what fails, what's missing."
+```
+
+**Test agent B** — error handling and consistency:
+
+```text
+subagent_type: general-purpose
+prompt: "Test {cli_command}'s error handling and consistency (run from {working_dir}).
+Run: commands with missing required args, invalid flag values, nonexistent files, wrong syntax.
+Check whether flag names are consistent across subcommands (--verbose always means the same thing).
+Check exit codes with echo $?. Capture exact outputs. Note every inconsistency."
+```
+
+Wait for all three agents to complete and collect their full outputs before proceeding.
+
+## Step 4: Launch synthesizer agent
+
+Once all evaluation results are collected, launch the `cli-ux-tester:cli-ux-tester` agent.
+
+Pass:
 
 - The working directory
 - The CLI entry point (command name, script path, or executable)
-- Any relevant context from the user's message (e.g., "focus on error messages", "check the help system")
-- Paths to the reference files:
-  - Use Glob (`**/testing-checklist.md`) to locate `testing-checklist.md`
-  - Use Glob (`**/test-scenarios.md`) to locate `test-scenarios.md`
+- Any relevant context from the user's message (e.g., "focus on error messages")
+- The full output from all three evaluation agents (Explore, Test A, Test B)
+- Path to `testing-checklist.md`
+- Path to `test-scenarios.md`
 
-## Step 4: Report results
+## Step 5: Report results
 
 When the agent completes, inform the user:
 


### PR DESCRIPTION
## Summary

- **#4** Fix sub-agent nesting — the platform prohibits sub-agents spawning further sub-agents.
  The three evaluation agents (Explore, Test A, Test B) are moved into the skill, which spawns
  them in parallel directly from the current session. The `cli-ux-tester` agent is now a pure
  synthesizer: it receives `{explore_results}`, `{test_a_results}`, `{test_b_results}` from the
  skill and produces scored artifacts. `Agent` removed from agent tools list.

- **#10** Add `permissionMode: acceptEdits` to agent frontmatter — auto-approves the 4 artifact
  file writes (`EVALUATION.md`, `REMEDIATION_PLAN.md`, `metrics.json`, `test.sh`) without
  bypassing `Bash` permission prompts, keeping the right balance between automation and security.

- **#12** Add `memory: user` to agent frontmatter — enables cross-evaluation learning at
  `~/.claude/agent-memory/cli-ux-tester/`. Adds a **Memory guidance** section in the agent prompt
  documenting what to persist (cross-CLI patterns, baseline scores, notable UX examples) and what
  to avoid (raw test output, full reports).

## Test plan

- [ ] SKILL.md Step 3 spawns all three evaluation agents; Step 4 launches the synthesizer
- [ ] Agent frontmatter has `permissionMode: acceptEdits`, `memory: user`, no `Agent` in tools
- [ ] Agent workflow says "You do not spawn sub-agents" and receives `{explore_results}` etc.
- [ ] Memory guidance section present with do/don't guidance
- [ ] `markdownlint '*.md' 'agents/*.md' 'skills/**/*.md'` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)